### PR TITLE
Pre-include the activity as part of the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Meet the powerful Android multi-image picker module built by using RecyclerView 
 
 ## Requirements & Installation
 * Ti SDK >= 6.0.0.GA
-* [Download module from here](android/dist/in.prashant.imagepicker-android-1.0.0.zip)
+* [Download module from here](https://github.com/prashantsaini1/titanium-android-imagepicker/raw/master/android/dist/in.prashant.imagepicker-android-1.0.0.zip)
 * Unzip it, put it in your Titanium project modules folder & add this line to your tiapp.xml <modules> node.
 
 ```

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -7,6 +7,7 @@
 	<iphone>
 	</iphone>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
+		<activity android:name="in.prashant.imagepicker.Recycler_Activity"/>
 	</android>
 	<mobileweb>
 	</mobileweb>


### PR DESCRIPTION
When running the module as is it will break on a missing android activity that needs to be added to the tiapp.xml file manually.
By including the activity as part of the timodule.xml, this will save the developer who's using this module the extra setup (which is currently is not documented)